### PR TITLE
Transfer `valueDifference` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,48 +46,40 @@ Tests are written in `test/nft-barter.js`
 
 ## How NFT-Barter works
 
-NFT-Barter provides an easy-to-use functionality for it's users to swap their NFT with someone else's.
+NFT-Barter provides an easy-to-use functionality for it's users to swap their NFTs with someone else's. Users can mint their NFTs, swap their NFTs, and transfer FTs to contract. NFT-Barter keeps a ledger to maintain the balance for each address. The amount for the specified address is deducted and transferred to the other participant after the swap is successful.
 **mint(uint256  tokenId)**
 This function takes the `tokenId` as param. It associates the NFT id with the user that calls this function.
 **initiateFixedSwap(uint256  makerTokenId,uint256  takerTokenId,int152  valueDifference)**
  - `makerTokenId` denotes to the token id that is associated with the person creating the swap (or the owner of that purticular swap)
  - `takerTokenId` refers to the token, the owner wishes to swap with
- - `valueDifference` is the difference of value between the worth of both NFTs
+ - `valueDifference` is the difference of value between the worth of both NFTs. Negative valueDifference transfers the amount from maker to taker's account and vice versa for positive valueDifference, when taker accepts the swap. In case of zero valueDifference, no transaction will be made other than swapping the two tokens.
 
 Criteria to execute this function:
 - `makerTokenId` should be owned by the maker of this swap
 - `takerTokenId` should be owned by the taker of this swap
 
-`
-Note: This is a payable function. Negative valueDifference transfers the amount from maker to taker's account and vice versa for positive valueDifference when taker accepts the swap. In case for zero valueDifference, no transaction will be made other than swapping the two tokens.
-`
-
 **updateSwapValue(uint128  swapId, int152  valueDifference)**
 An update function to update the `valueDifference` of the specific swap. 
 Criteria to execute this function:
-- Sender has to be the owner / maker of the swap
+- Sender has to be the owner of the swap
 - Swap should exist
-
-`
-Note: This is a payable function. In case of negative valueDifference, the difference is either credited into the owner's account or debited from the owner's account depending upon the difference in old and new value.
-`
 
 **updateSwapMakerToken(uint128  swapId, uint256  makerTokenId)**
 An update function to update the `makerTokenId` of the specific swap.
 Criteria to execute this function:
-- Sender has to be the owner / maker of the swap
+- Sender has to be the owner of the swap
 - Swap should exist
 - Token should be minted by maker
 
 **updateSwapTakerToken(uint128  swapId, uint256  takerTokenId)**
 An update function to update the `takerTokenId` of a swap.
 Criteria to execute this function:
-- Sender has to be the owner / maker of the swap
+- Sender has to be the owner of the swap
 - Swap should exist
 - Token should be minted by taker
 
 **acceptSwap(uint128  swapId, uint256  takerTokenId)**
-A function that ends the transaction in a successful manner. Notifying that both NFTs have been successfully transfered along with the amount stated in `valueDifference`.
+A function that ends the transaction in a successful manner. Notifying that both NFTs have been successfully swapped along with the amount stated in `valueDifference`.
 Criteria to execute this function:
 - Sender has to be the taker
 - Swap should exist
@@ -102,11 +94,18 @@ Criteria to execute this function:
 - Sender has to be either the taker or maker of this swap
 - Swap should exist
 
-`
-Note: This is a payable function. It transfers the amount taken from maker at the time of initiateFixedSwap or updateSwapValue back to the maker of this swap.
-`
-
 **isSwapPossible(uint128  swapId)**
 This is a helper function to test if the swap is still valid or not. The swap will be stale in case, the owner of any `tokenId` associated with that purticular swap have been updated.
 Criteria to execute this function:
 - Swap should exist
+
+**withdrawAmount(uint256 amount)**
+This function enables the users to withdraw their amount from NFT-Barter.
+Criteria to execute this function:
+- The amount specified should be less than or equal to the balance
+`
+Note: This is a payable function. It transfers the amount to the caller and updates their balance.
+`
+
+**checkBalance()**
+This function helps the users to check their balance in NFT-Barter.

--- a/README.md
+++ b/README.md
@@ -46,40 +46,48 @@ Tests are written in `test/nft-barter.js`
 
 ## How NFT-Barter works
 
-NFT-Barter provides an easy-to-use functionality for it's users to swap their NFTs with someone else's. Users can mint their NFTs, swap their NFTs, and transfer FTs to contract. NFT-Barter keeps a ledger to maintain the balance for each address. The amount for the specified address is deducted and transferred to the other participant after the swap is successful.
+NFT-Barter provides an easy-to-use functionality for it's users to swap their NFT with someone else's.
 **mint(uint256  tokenId)**
 This function takes the `tokenId` as param. It associates the NFT id with the user that calls this function.
 **initiateFixedSwap(uint256  makerTokenId,uint256  takerTokenId,int152  valueDifference)**
  - `makerTokenId` denotes to the token id that is associated with the person creating the swap (or the owner of that purticular swap)
  - `takerTokenId` refers to the token, the owner wishes to swap with
- - `valueDifference` is the difference of value between the worth of both NFTs. Negative valueDifference transfers the amount from maker to taker's account and vice versa for positive valueDifference, when taker accepts the swap. In case of zero valueDifference, no transaction will be made other than swapping the two tokens.
+ - `valueDifference` is the difference of value between the worth of both NFTs
 
 Criteria to execute this function:
 - `makerTokenId` should be owned by the maker of this swap
 - `takerTokenId` should be owned by the taker of this swap
 
+`
+Note: This is a payable function. Negative valueDifference transfers the amount from maker to taker's account and vice versa for positive valueDifference when taker accepts the swap. In case for zero valueDifference, no transaction will be made other than swapping the two tokens.
+`
+
 **updateSwapValue(uint128  swapId, int152  valueDifference)**
 An update function to update the `valueDifference` of the specific swap. 
 Criteria to execute this function:
-- Sender has to be the owner of the swap
+- Sender has to be the owner / maker of the swap
 - Swap should exist
+
+`
+Note: This is a payable function. In case of negative valueDifference, the difference is either credited into the owner's account or debited from the owner's account depending upon the difference in old and new value.
+`
 
 **updateSwapMakerToken(uint128  swapId, uint256  makerTokenId)**
 An update function to update the `makerTokenId` of the specific swap.
 Criteria to execute this function:
-- Sender has to be the owner of the swap
+- Sender has to be the owner / maker of the swap
 - Swap should exist
 - Token should be minted by maker
 
 **updateSwapTakerToken(uint128  swapId, uint256  takerTokenId)**
 An update function to update the `takerTokenId` of a swap.
 Criteria to execute this function:
-- Sender has to be the owner of the swap
+- Sender has to be the owner / maker of the swap
 - Swap should exist
 - Token should be minted by taker
 
 **acceptSwap(uint128  swapId, uint256  takerTokenId)**
-A function that ends the transaction in a successful manner. Notifying that both NFTs have been successfully swapped along with the amount stated in `valueDifference`.
+A function that ends the transaction in a successful manner. Notifying that both NFTs have been successfully transfered along with the amount stated in `valueDifference`.
 Criteria to execute this function:
 - Sender has to be the taker
 - Swap should exist
@@ -94,18 +102,11 @@ Criteria to execute this function:
 - Sender has to be either the taker or maker of this swap
 - Swap should exist
 
+`
+Note: This is a payable function. It transfers the amount taken from maker at the time of initiateFixedSwap or updateSwapValue back to the maker of this swap.
+`
+
 **isSwapPossible(uint128  swapId)**
 This is a helper function to test if the swap is still valid or not. The swap will be stale in case, the owner of any `tokenId` associated with that purticular swap have been updated.
 Criteria to execute this function:
 - Swap should exist
-
-**withdrawAmount(uint256 amount)**
-This function enables the users to withdraw their amount from NFT-Barter.
-Criteria to execute this function:
-- The amount specified should be less than or equal to the balance
-`
-Note: This is a payable function. It transfers the amount to the caller and updates their balance.
-`
-
-**checkBalance()**
-This function helps the users to check their balance in NFT-Barter.

--- a/nft-barter-core/contracts/nft-barter.sol
+++ b/nft-barter-core/contracts/nft-barter.sol
@@ -9,9 +9,14 @@ contract NFTBarter is ERC721, INFTFixedBarter {
     string private constant PERMISSION_DENIED = "1001: permission denied";
     string private constant INVALID_SWAP = "1002: invalid swap";
     string private constant USELESS_SWAP = "1003: useless swap"; //swap is not useable anymore some informatino in the swap is probably changed like ownership
+    string private constant INSUFFICIENT_BALANCE = "1004: insufficient balance";
+    string private constant TX_FAILED = "1005: transaction failed";
 
     //mapping based on swapId
     mapping(uint128 => SwapOrder) private _swaps;
+
+    //mapping to keep record for user's balance transferred
+    mapping(address => uint256) private _ledger;
 
     //swapId generator
     uint128 private _swapCounter;
@@ -22,8 +27,8 @@ contract NFTBarter is ERC721, INFTFixedBarter {
 
     //modifiers
     modifier onlyIfTokenIsValid(uint256 tokenId) {
-      require(ERC721._exists(tokenId), INVALID_TOKEN_ID);
-      _;
+        require(ERC721._exists(tokenId), INVALID_TOKEN_ID);
+        _;
     }
 
     modifier onlyIfValidSwap(uint256 makerTokenId, uint256 takerTokenId) {
@@ -55,11 +60,21 @@ contract NFTBarter is ERC721, INFTFixedBarter {
         _;
     }
 
+    modifier onlyIfMaker(uint128 swapId) {
+        SwapOrder memory swap = _swaps[swapId];
+        require(swap.makerAddress == msg.sender, PERMISSION_DENIED);
+        _;
+    }
+
     //events
     event SwapInitiated(SwapOrder swap);
     event SwapUpdate(bytes20 updateProperty, SwapOrder updatedSwap);
     event SwapCanceled(SwapOrder swap);
     event SwapAccepted(SwapOrder swap);
+
+    receive() external payable {
+        _ledger[msg.sender] += msg.value;
+    }
 
     //implementation
     function mint(uint256 tokenId) external {
@@ -97,7 +112,7 @@ contract NFTBarter is ERC721, INFTFixedBarter {
         external
         override
         onlyIfSwapExists(swapId)
-        onlyIfParticipant(swapId)
+        onlyIfMaker(swapId)
         returns (SwapOrder memory)
     {
         SwapOrder memory swap = _swaps[swapId];
@@ -114,7 +129,7 @@ contract NFTBarter is ERC721, INFTFixedBarter {
         override
         onlyIfSwapExists(swapId)
         onlyIfTokenIsValid(makerTokenId)
-        onlyIfParticipant(swapId)
+        onlyIfMaker(swapId)
         returns (SwapOrder memory)
     {
         SwapOrder memory swap = _swaps[swapId];
@@ -130,14 +145,14 @@ contract NFTBarter is ERC721, INFTFixedBarter {
         override
         onlyIfSwapExists(swapId)
         onlyIfTokenIsValid(takerTokenId)
-        onlyIfParticipant(swapId)
+        onlyIfMaker(swapId)
         returns (SwapOrder memory)
     {
         SwapOrder memory swap = _swaps[swapId];
         swap.takerTokenId = takerTokenId;
         _updateSwapsData(swap);
 
-        emit SwapUpdate("MakerUpdate", swap);
+        emit SwapUpdate("TakerUpdate", swap);
         return swap;
     }
 
@@ -175,8 +190,29 @@ contract NFTBarter is ERC721, INFTFixedBarter {
             swap.makerAddress,
             swap.takerTokenId
         );
+        if (swap.valueDifference < 0) {
+            _transferAmount(
+                swap.makerAddress,
+                swap.takerAddress,
+                _abs(swap.valueDifference)
+            );
+        } else if (swap.valueDifference > 0) {
+            _transferAmount(
+                swap.takerAddress,
+                swap.makerAddress,
+                _abs(swap.valueDifference)
+            );
+        }
         emit SwapAccepted(swap);
         return true;
+    }
+
+    function withdrawAmount(uint256 amount) external payable {
+        _transferAmount(msg.sender, msg.sender, amount);
+    }
+
+    function checkBalance() external view returns (uint256) {
+        return _ledger[msg.sender];
     }
 
     function isSwapPossible(uint128 swapId)
@@ -197,7 +233,10 @@ contract NFTBarter is ERC721, INFTFixedBarter {
         _swaps[swap.swapId] = swap;
     }
 
-    function _clearSwapsData(uint128 swapId) private returns (SwapOrder memory){
+    function _clearSwapsData(uint128 swapId)
+        private
+        returns (SwapOrder memory)
+    {
         SwapOrder memory swap = _swaps[swapId];
 
         delete _swaps[swap.swapId];
@@ -205,8 +244,26 @@ contract NFTBarter is ERC721, INFTFixedBarter {
         return swap;
     }
 
+    function _abs(int256 x) private pure returns (uint256) {
+        return x >= 0 ? uint256(x) : uint256(-x);
+    }
+
     function _getNextId() private returns (uint128) {
         _swapCounter = _swapCounter + 1;
         return _swapCounter;
+    }
+
+    function _transferAmount(
+        address from,
+        address to,
+        uint256 amount
+    ) private {
+        // checking from's account
+        require(amount <= _ledger[from], INSUFFICIENT_BALANCE);
+        // subtracting the amount in ledger
+        _ledger[from] -= amount;
+        // transferring the amount to `to`
+        (bool sent, ) = payable(to).call{value: amount}("");
+        require(sent, TX_FAILED);
     }
 }

--- a/nft-barter-core/interfaces/INFTFixedBarter.sol
+++ b/nft-barter-core/interfaces/INFTFixedBarter.sol
@@ -17,14 +17,14 @@ abstract contract INFTFixedBarter is INFTBarter {
     @param takerTokenId token id of the taker of this swap
     @param valueDifference the value that the maker is willing to pay/receive for this swap, 0 means there is nothign to pay, postive value means maker wants to pay that much, negative value means maker want to recieve that much
      */
-    function initiateFixedSwap(uint makerTokenId, uint takerTokenId, int152 valueDifference) external virtual returns(SwapOrder memory);
+    function initiateFixedSwap(uint makerTokenId, uint takerTokenId, int152 valueDifference) payable external virtual returns(SwapOrder memory);
 
     /**
     @notice updates the difference value of a swap
     @param swapId swapId for swap to modify
     @param valueDifference new value for this swap
      */
-    function updateSwapValue(uint128 swapId, int152 valueDifference) external virtual returns(SwapOrder memory);
+    function updateSwapValue(uint128 swapId, int152 valueDifference) external payable virtual returns(SwapOrder memory);
 
     /**
     @notice updates the nft for maker of the swap
@@ -46,5 +46,5 @@ abstract contract INFTFixedBarter is INFTBarter {
     @param swapId swapId of the swap to be canceled
     @return true of swap is canceled , false if swap could not be canceled for some reason
      */
-    function cancelSwap(uint128 swapId) external virtual returns(SwapOrder memory);
+    function cancelSwap(uint128 swapId) external payable virtual returns(SwapOrder memory);
 }

--- a/nft-barter-core/test/test-helpers.js
+++ b/nft-barter-core/test/test-helpers.js
@@ -3,6 +3,7 @@ const { assert } = require("chai");
 const ERROR_INVALID_TOKEN_ID = "1000: invalid token id";
 const ERROR_INVALID_SWAP = "1002: invalid swap";
 const ERROR_PERMISSION_DENIED = "1001: permission denied";
+const ERROR_INSUFFICIENT_BALANCE = "1004: insufficient balance";
 
 const EVENT_SWAP_INITIATED = "SwapInitiated";
 const EVENT_SWAP_UPDATED = "SwapUpdate";
@@ -10,8 +11,8 @@ const EVENT_SWAP_CANCELED = "SwapCanceled";
 const EVENT_SWAP_ACCEPTED = "SwapAccepted";
 
 function checkDataFromEvent(event, structName, expected, eventType) {
-//   const typeOfEvent = event.logs[0].event;
-const logsIndex = event.logs.findIndex(log => log.event === eventType);
+  //   const typeOfEvent = event.logs[0].event;
+  const logsIndex = event.logs.findIndex((log) => log.event === eventType);
   assert.isTrue(logsIndex > -1);
   const dataArr = event.receipt.logs[logsIndex].args[structName];
   const expectedKeys = Object.keys(expected);
@@ -25,6 +26,7 @@ module.exports = {
   ERROR_PERMISSION_DENIED,
   ERROR_INVALID_SWAP,
   ERROR_INVALID_TOKEN_ID,
+  ERROR_INSUFFICIENT_BALANCE,
   EVENT_SWAP_INITIATED,
   EVENT_SWAP_UPDATED,
   EVENT_SWAP_CANCELED,

--- a/nft-barter-core/test/test-helpers.js
+++ b/nft-barter-core/test/test-helpers.js
@@ -3,7 +3,7 @@ const { assert } = require("chai");
 const ERROR_INVALID_TOKEN_ID = "1000: invalid token id";
 const ERROR_INVALID_SWAP = "1002: invalid swap";
 const ERROR_PERMISSION_DENIED = "1001: permission denied";
-const ERROR_INSUFFICIENT_BALANCE = "1004: insufficient balance";
+const INVALID_BALANCE_TRANSFERRED = "1004: invalid balance transferred";
 
 const EVENT_SWAP_INITIATED = "SwapInitiated";
 const EVENT_SWAP_UPDATED = "SwapUpdate";
@@ -26,7 +26,7 @@ module.exports = {
   ERROR_PERMISSION_DENIED,
   ERROR_INVALID_SWAP,
   ERROR_INVALID_TOKEN_ID,
-  ERROR_INSUFFICIENT_BALANCE,
+  INVALID_BALANCE_TRANSFERRED,
   EVENT_SWAP_INITIATED,
   EVENT_SWAP_UPDATED,
   EVENT_SWAP_CANCELED,


### PR DESCRIPTION
# Description

This PR adds the functionality to transfer the `valueDifference`.
The updated code takes FT from the user at the point when it's required. Following are the cases where **maker** is supposed to transfer the amount to the contract:
- `initiateFixedSwap`: If the `valueDifference` is -ve
- `updateSwapValue`: If the new `valueDifference` is lower (in terms of -ve) than old value

The following cases involve the process where **taker** is supposed to transfer the amount to the contract:
- `acceptSwap`: If the `valueDifference` is positive

The following cases involve the process where **contract** is supposed to transfer the amount to the maker: 
- `updateSwapValue`: If the new `valueDifference` is +ve or higher (in terms of -ve) than old value
- `cancelSwap`: If the `valueDifference` is -ve

Fixes #21 #23 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] `npm test` passes.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
